### PR TITLE
Removed map button from User Portal

### DIFF
--- a/src/components/UserPortal/UserPortal.js
+++ b/src/components/UserPortal/UserPortal.js
@@ -56,9 +56,6 @@ const UserPortal = (props) => {
         <Link to="/berlin">
           <button>{portalLocales.rooms[lang]}</button>
         </Link>
-        <Link to="/maps">
-          <button>{portalLocales.map[lang]}</button>
-        </Link>
         {renderedLinks}
       </div>
     </div>


### PR DESCRIPTION
Removed Map button since it is not working now. 
Ticket: https://trello.com/c/lsWjpAXy/77-remove-map-button-from-userportal