### PR TITLE
Bugfix/106 landing page localization

### DIFF
--- a/src/locales/locales.home.json
+++ b/src/locales/locales.home.json
@@ -1,4 +1,12 @@
 {
+  "senior":{
+    "en": "Seniors",
+    "de": "Senioren"
+  },
+  "young":{
+    "en": "Young",
+    "de": "Junge"
+  },
   "youthB": {
     "en": "For young people:",
     "de": "Für junge Leute:"

--- a/src/locales/locales.home.json
+++ b/src/locales/locales.home.json
@@ -5,7 +5,7 @@
   },
   "young":{
     "en": "Young",
-    "de": "Junge"
+    "de": "Jung"
   },
   "youthB": {
     "en": "For young people:",

--- a/src/pages/home/Home.js
+++ b/src/pages/home/Home.js
@@ -54,7 +54,7 @@ class Home extends Component {
         <How id="how-it-works">
           <H2 titleColor="white" className="how-it-works-title">{homeLocales.how[lang]}</H2>
           <div className="category-title-container">
-            <div className="category-title">Seniors</div>
+            <div className="category-title">{homeLocales.senior[lang]}</div>
           </div>
           <HowFlex>
             <Card2 title="#1" text={homeLocales.step_1_sr[lang]} />
@@ -66,7 +66,7 @@ class Home extends Component {
         </How>
         <How backgroundColor="#CFE7F0" id="how-it-works">
           <div className="category-title-container">
-            <div className="category-title">Young</div>
+            <div className="category-title">{homeLocales.young[lang]}</div>
           </div>
           <HowFlex>
             <Card2 title="#1" text={homeLocales.step_1_jr[lang]} />


### PR DESCRIPTION
German version of the platform
- Change “Seniors” to “Senioren”
- Change “Young” to “Jung”

***Note: used 'Jung' instead of 'Junge Menschen' because it fits better with the styling

Ticket: https://trello.com/c/harm4aTc/106-landing-page-wie-funktioniert-es-change-english-titles-into-german